### PR TITLE
fix Roam-as-a-slip-box-link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A curated list of https://roamresearch.com/ resources
   - [Building a Second Brain in Roam...And Why You Might Want To : RoamResearch](https://www.reddit.com/r/RoamResearch/comments/eho7de/building_a_second_brain_in_roamand_why_you_might/)
   - [How to use Roam Research: a tool for metacognition - Ness Labs](https://nesslabs.com/roam-research)
   - [Note taking and Roam](http://reganmian.net/blog/2020/01/31/note-taking-with-roam/)
-  - [Roam as a slip-box](https://davidklaing.com/blog/2020/02/01/roam-as-a-slip-box.html)
+  - [Roam as a slip-box](https://davidklaing.com/roam-as-a-slip-box/)
   - [Roam features that have changed the way I take notes](https://www.mozzafiller.com/posts/roam-features)
 
 ## Documentation & Help


### PR DESCRIPTION
working my way through these lovely examples I noticed the roam-as-a-slip-box link had changed, roam has me in a pruning and upkeep mode!